### PR TITLE
v1.4

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -260,29 +260,19 @@ local function DrawRuleRow(entry)
     end
     ImGui.TableNextColumn()
     ImGui.Text('%s', entry.MobName)
-    if entry.MobID ~= nil then
-        if ImGui.IsItemHovered() and ImGui.IsMouseReleased(ImGuiMouseButton.Right) then CMD('/target id '..entry.MobID) end
-    end
+
     ImGui.TableNextColumn()
     ImGui.Text('%s', (entry.MobLvl))
-    if entry.MobLvl ~= nil then
-        if ImGui.IsItemHovered() and ImGui.IsMouseReleased(ImGuiMouseButton.Right) then CMD('/target id '..entry.MobID) end
-    end
+
     ImGui.TableNextColumn()
     ImGui.Text('%s', (entry.MobDist))
-    if entry.MobID ~= nil then
-        if ImGui.IsItemHovered() and ImGui.IsMouseReleased(ImGuiMouseButton.Right) then CMD('/target id '..entry.MobID) end
-    end
+
     ImGui.TableNextColumn()
     ImGui.Text('%s', (entry.MobID))
-    if entry.MobID ~= nil then
-        if ImGui.IsItemHovered() and ImGui.IsMouseReleased(ImGuiMouseButton.Right) then CMD('/target id '..entry.MobID) end
-    end
+
     ImGui.TableNextColumn()
     ImGui.Text('%s', (entry.MobLoc))
-    if entry.MobID ~= nil then
-        if ImGui.IsItemHovered() and ImGui.IsMouseReleased(ImGuiMouseButton.Right) then CMD('/target id '..entry.MobID) end
-    end
+
     ImGui.TableNextColumn()
     ImGui.SameLine()
     if ImGui.SmallButton("Add##" .. entry.ID) then CMD('/am spawnadd "'..entry.MobName..'"') end
@@ -478,7 +468,6 @@ local function DrawSearchWindow()
                             -- Right-click interaction uses the original spawnName
                             if ImGui.IsItemHovered() and ImGui.IsMouseReleased(1) then
                                 CMD('/nav spawn "' .. spawnName .. '"')
-                                CMD('/target ${Spawn[npc ' .. spawnName .. ']}')
                             end
                         end
                         
@@ -523,7 +512,6 @@ local function BuildAlertRows() -- Build the Button Rows for the GUI Window
                 if ImGui.Button(spawnData.CleanName() .. "##" .. spawnData.ID()) then
                     -- Actions tied to this specific spawn
                     CMD('/nav id ' .. spawnData.ID())
-                    CMD('/target id ' .. spawnData.ID())
                 end
                 if ImGui.IsItemHovered() then
                     ImGui.BeginTooltip()


### PR DESCRIPTION
*Spawns saved with _ values aka Spawn.Name instead of CleanName will display Clean Names.
*You can add target to the list by entering ${Target.Name} or ${Target.CleanName} in the add textbox.
*Now the tab will change color if spawns are up.
*Fixed the logic when deleting a spawn from the spawnlist.
*now it will renumber the spawns to fix the missing number in sequence.
*Added Alert Window toggle button on main window.
*Fixed some formatting on the tables.
*Removed the targeting command.
as aquietone pointed out we probably shouldn't target a mob across the zone.